### PR TITLE
Agregar API Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,5 @@ Outline general del curso https://docs.google.com/document/d/1D-7fi5afo_kgDFLi_n
 * Ejecutar `yarn start` en el directorio para iniciar el server
 
 ## TODO
-* Agregar videos de react
 * Refactorizar el drawer/drawerContent
-* Cache para las api request
 * Agregar error boundary
-* Agregar .env variables

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -4,16 +4,19 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import Content from '../Content'
 import theme from '../../ui/theme';
+import { CacheProvider } from '../../utils/cache';
 
 function App() {
   return (
     <>
       <CssBaseline />
-        <ThemeProvider theme={theme}>
-          <Router>
+      <ThemeProvider theme={theme}>
+        <Router>
+          <CacheProvider>
             <Content />
-          </Router>
-        </ThemeProvider>
+          </CacheProvider>
+        </Router>
+      </ThemeProvider>
     </>
   );
 }

--- a/src/components/Curso/index.js
+++ b/src/components/Curso/index.js
@@ -51,7 +51,7 @@ const Curso = ({ react = false }) => {
           </Typography>
         </>
       )}
-      {loading ? (
+      {loading || !clases ? (
         <div className={classes.circularProgress}>
           <CircularProgress size={68}/>
         </div>

--- a/src/reducers/fetchReducer.js
+++ b/src/reducers/fetchReducer.js
@@ -13,7 +13,6 @@ export default (state, action) => {
     case FETCH_SUCCESS:
       return {
         ...state,
-        clases: action.payload,
         loading: false,
         error: false
       }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,5 +1,6 @@
-import { useReducer, useEffect } from 'react';
-import clasesFetchReducer, {FETCH_INIT, FETCH_ERROR, FETCH_SUCCESS} from '../reducers/clasesFetchReducer';
+import { useReducer, useEffect, useContext } from 'react';
+import fetchReducer, { FETCH_INIT, FETCH_ERROR, FETCH_SUCCESS } from '../reducers/fetchReducer';
+import { CacheContext, SET_CACHE } from './cache';
 
 const KEY = process.env.REACT_APP_YOUTUBE_API_KEY;
       
@@ -9,14 +10,15 @@ const reactClasesPlaylistId = 'PLs73pLtDNXD_l2bEVFi1Yqph1f6pDvCnW';
 const javascriptClasesPlaylistId = 'PLs73pLtDNXD893LSF8fP-EfZbGWMECmnc';
 
 export function useFetchPlaylist (react = false) {
-  const playlistId = react ? reactClasesPlaylistId : javascriptClasesPlaylistId;
-  const [state, dispatch] = useReducer(clasesFetchReducer, {
-    loading: true,
+  const cache = useContext(CacheContext);
+  const cacheClases = react ? cache.state.react : cache.state.javascript;
+  const [{ loading, error }, dispatch] = useReducer(fetchReducer, {
+    loading: false,
     error: false,
-    clases: null
-  })
+  });
 
   useEffect(() => {
+    const playlistId = react ? reactClasesPlaylistId : javascriptClasesPlaylistId;
     const fetchData = async () => {
       dispatch({ type: FETCH_INIT });
 
@@ -26,17 +28,25 @@ export function useFetchPlaylist (react = false) {
 
         dispatch({
           type: FETCH_SUCCESS,
-          payload: generateClases(responseJson)
+        });
+        cache.dispatch({
+          type: SET_CACHE,
+          payload: {
+            key: react ? 'react' : 'javascript',
+            value: generateClases(responseJson),
+          },
         });
       } catch (error) {
-        dispatch({ type: FETCH_ERROR })
+        dispatch({ type: FETCH_ERROR });
       }
     };
 
-    fetchData();
-  }, [playlistId]);
+    if (!loading && !cacheClases) {
+      fetchData();
+    }
+  }, [loading, cache, react, cacheClases]);
 
-  return state;
+  return { loading, error, clases: cacheClases };
 }
 
 function generateClases ({items}) {

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,0 +1,27 @@
+import React, { useReducer, createContext } from 'react';
+
+export const CacheContext = createContext();
+CacheContext.displayName = 'Cache'
+
+export const SET_CACHE = 'SET_CACHE';
+const cacheReducer = (state, action) => {
+  const { type, payload } = action;
+  switch (type) {
+    case SET_CACHE:
+      return {
+        ...state,
+        [payload.key]: payload.value,
+      };
+    default:
+      return state;
+  }
+};
+
+export function CacheProvider({ children }) {
+  const [state, dispatch] = useReducer(cacheReducer, {
+    javascript: null,
+    react: null,
+  });
+
+  return <CacheContext.Provider value={{ state, dispatch }}>{children}</CacheContext.Provider>;
+}


### PR DESCRIPTION
Agregué un cache usando Context+useReducer (algo parecido a una implementación de redux pero sin instalar toda la librería). También cambié el reducer que armaste para que solo trackee loading/error, ya que las clases se guardan en el reducer de CacheProvider.
Si querés que reorganize algo comentá nomás.